### PR TITLE
setup automatic code coverage reports with Jest

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "dev:build": "tsc -w",
     "dev:run": "node --watch dist/server.js",
     "dev": "npm run build && (npm run dev:build & npm run dev:run)",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
+    "test:coverage": "jest --coverage --runInBand"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
"npm run test:coverage" to generate code coverage reports to terminal and ./coverage/lcov-report/index.html
setup automatic code coverage reports with Jest to evaluate test suites
 